### PR TITLE
Fixing namespace mismatch issue

### DIFF
--- a/src/DatadogLogsHttpLogger.php
+++ b/src/DatadogLogsHttpLogger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Datadog;
+namespace Drupal\datadog;
 
 use Drupal\logs_http\Logger\LogsHttpLogger;
 use Drupal\Core\Site\Settings;


### PR DESCRIPTION
Motivation:
The following error is showing while running phpunit:

```
RuntimeException: Case mismatch between loaded and declared class names: "Drupal\datadog\DatadogLogsHttpLogger" vs "Drupal\Datadog\DatadogLogsHttpLogger"
```
Fix:
Unify the namespace name, since it uses `Datadog` in one file and `datadog` in another.